### PR TITLE
Create Expo map app with location permissions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  root: true,
+  extends: ['expo', 'expo/typescript'],
+  rules: {
+    'react-hooks/exhaustive-deps': 'warn'
+  }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+.expo/
+.expo-shared/
+dist/
+build/
+web-build/
+.env
+npm-debug.log*
+yarn-error.log*
+.DS_Store

--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,1 @@
+export { default } from './src/App';

--- a/README.md
+++ b/README.md
@@ -1,2 +1,119 @@
-# Profile-sytem
-SCRM Profile section
+# Expo Standortkarte
+
+Eine Expo-App (TypeScript) mit React Native Maps, die beim Start nach der Standortfreigabe fragt, die aktuelle Nutzerposition auf einer interaktiven Karte anzeigt und klare Hinweise für alle Berechtigungs- und GPS-Fehlerfälle liefert.
+
+## Hauptfunktionen
+
+- Einmaliger Foreground-Permission-Request beim ersten Start.
+- Vollbildkarte mit `react-native-maps`, Nutzerposition & sanfter Zentrierung.
+- Floating-Action-Button „Meine Position zentrieren“.
+- Ausgereiftes Fehlerhandling für verweigerte/gesperrte Berechtigungen, deaktivierte Standortdienste und Timeouts.
+- Barrierearme Hinweise und Handlungsoptionen (erneut anfragen, zu den Systemeinstellungen wechseln).
+
+## Voraussetzungen
+
+- [Node.js](https://nodejs.org/) **>= 18** (empfohlen: aktuelle LTS-Version)
+- [Expo CLI](https://docs.expo.dev/more/expo-cli/) (`npm install -g expo-cli`) oder Verwendung von `npx expo`
+- Ein aktives Expo-Konto für EAS-Builds (optional)
+
+## Installation
+
+1. Repository klonen und Abhängigkeiten installieren:
+
+   ```bash
+   git clone <repo-url>
+   cd Profile-sytem
+   npm install
+   ```
+
+2. Optional: Eine `.env`-Datei anlegen, um Secrets wie den Google-Maps-API-Key zentral zu pflegen. Expo liest die Variablen zur Build-Zeit ein.
+
+   ```bash
+   echo "GOOGLE_MAPS_API_KEY=dein-key" >> .env
+   ```
+
+3. Stelle sicher, dass die benötigten Plattform-Tools vorhanden sind (Xcode-Simulator, Android Studio & Emulator, Expo Go App auf realen Geräten).
+
+## Plattformkonfiguration
+
+### iOS
+
+- Die InfoPlist-Message für die Foreground-Location wird in `app.config.js` gesetzt (`NSLocationWhenInUseUsageDescription`).
+- Passe den Text bei Bedarf an eure Kommunikationsrichtlinien an.
+
+### Android
+
+- Angeforderte Berechtigungen: `ACCESS_FINE_LOCATION` (Foreground). Optional kann `ACCESS_COARSE_LOCATION` ergänzt werden, wenn geringere Genauigkeit genügt.
+- Der Google-Maps-API-Key wird über `app.config.js` aus `process.env.GOOGLE_MAPS_API_KEY` gelesen. Lege den Wert für Builds/CI als Secret an (z. B. in EAS Secrets, GitHub Actions oder lokal in `.env`).
+- Ohne gesetzten Key zeigt Google Maps auf Android keine Tiles an.
+
+### Google Maps API-Key setzen
+
+- **Lokal**: `.env` mit `GOOGLE_MAPS_API_KEY=...` anlegen und `expo start` via `npx expo start --clear` neu starten.
+- **CI / EAS**: Den Key als Secret konfigurieren und bei Builds per Environment-Variable bereitstellen (`EXPO_PUBLIC_GOOGLE_MAPS_API_KEY` ist nicht nötig; die Config liest direkt `GOOGLE_MAPS_API_KEY`).
+- Der Key darf nicht im Repository liegen – nutze ausschließlich Environment-Variablen oder Secret Stores.
+
+## Entwicklung starten
+
+```bash
+npm start
+```
+
+Der Befehl startet Metro. Von dort aus:
+
+- **Android**: `a` drücken oder `npm run android`, um den Emulator zu öffnen. Stelle im Emulator sicher, dass „Google Play Services“ installiert sind.
+- **iOS**: `i` drücken oder `npm run ios`, um den iOS-Simulator zu starten (benötigt Xcode).
+- **Web**: `npm run web` öffnet eine Browser-Vorschau (limitiert bei Maps/Geolocation, primär für Layoutchecks gedacht).
+
+## Standort im Emulator simulieren
+
+### Android Studio
+
+1. Emulator starten.
+2. In den **Extended Controls** → **Location** wechseln.
+3. Einen Ort (Lat/Lng) auswählen oder eine GPX/KML-Datei laden.
+4. „Send“ drücken – Expo Go erhält nun den simulierten Standort.
+
+### Xcode Simulator
+
+1. Simulator öffnen und App ausführen.
+2. Menü **Features** → **Location** → Ort auswählen (z. B. „Freeway Drive“ oder „Custom Location…“).
+3. Für individuelle Koordinaten „Custom Location…“ wählen und Längen-/Breitengrade eingeben.
+
+## npm-Skripte
+
+| Befehl              | Zweck                                                   |
+| ------------------- | -------------------------------------------------------- |
+| `npm start`         | Metro Bundler mit QR-Code starten                        |
+| `npm run android`   | Projekt im Android-Emulator/auf einem angeschlossenen Gerät starten |
+| `npm run ios`       | Projekt im iOS-Simulator/auf einem angeschlossenen Gerät starten |
+| `npm run web`       | Web-Vorschau (keine produktive Plattform)                |
+| `npm test`          | Jest-Tests (Hooks-Smoketests) ausführen                  |
+| `npm run lint`      | ESLint prüfen (TypeScript-Regeln über `eslint-config-expo`) |
+| `npm run typecheck` | TypeScript-Typprüfung ohne Build                         |
+
+## Fehlerbehebung & Tipps
+
+- **Graue Karte / keine Tiles**: Prüfe den Google-Maps-API-Key, Internetverbindung oder Google Play Services (Android-Emulator). Auf iOS kann das Problem auftreten, wenn der Key nicht freigeschaltet ist.
+- **Position bleibt bei (0,0)**: Im Emulator ist kein Standort gesetzt. Folge der Anleitung oben, um einen simulierten Standort zu senden.
+- **Berechtigung dauerhaft „denied“**: In den Systemeinstellungen (iOS: Einstellungen → App, Android: Einstellungen → Apps → App → Berechtigungen) die Standortfreigabe zurücksetzen bzw. erneut erlauben.
+- **GPS deaktiviert**: Die App zeigt einen deutlichen Hinweis an. Aktiviere die Standortdienste (Android: Schnellzugriffe oder Einstellungen → Standort, iOS: Einstellungen → Datenschutz & Sicherheit → Ortungsdienste).
+- **Timeout bei Standortsuche**: Stelle sicher, dass das Gerät einen freien Himmel bzw. eine valide Positionsquelle hat. Ein Tippen auf „Erneut versuchen“ startet eine neue Anfrage.
+
+## Tests
+
+- Minimale Hook-Smoketests (`useLocationPermission`, `useCurrentPosition`) mit Jest & Testing Library (`npm test`).
+- TypeScript & ESLint prüfen (`npm run typecheck`, `npm run lint`). Alle Checks müssen ohne Fehler durchlaufen.
+
+## EAS Build (optional)
+
+1. Bei Expo anmelden: `npx expo login`.
+2. Projekt konfigurieren: `npx expo prebuild` ist **nicht** nötig; das Projekt nutzt Managed Workflow.
+3. Secrets setzen (z. B. `eas secret:create --name GOOGLE_MAPS_API_KEY --value <key>`).
+4. Builds starten:
+   - Android: `npx eas build -p android`
+   - iOS: `npx eas build -p ios`
+5. Für OTA-Updates: `npx eas update --branch production` (den API-Key vorher ebenfalls als Secret verfügbar machen).
+
+Weitere Hinweise: [Expo Location-Dokumentation](https://docs.expo.dev/versions/latest/sdk/location/) und [react-native-maps Setup](https://github.com/react-native-maps/react-native-maps#installation-and-configuration).
+

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+
+/** @type {import('@expo/config').ExpoConfig} */
+export default ({ config }) => ({
+  ...config,
+  name: 'Location Permission Map',
+  slug: 'location-permission-map',
+  version: '1.0.0',
+  orientation: 'portrait',
+  ios: {
+    supportsTablet: true,
+    infoPlist: {
+      NSLocationWhenInUseUsageDescription:
+        'Die App benötigt Ihren Standort, um Ihre Position auf der Karte anzeigen zu können.'
+    }
+  },
+  android: {
+    permissions: ['ACCESS_FINE_LOCATION'],
+    config: {
+      googleMaps: {
+        apiKey: process.env.GOOGLE_MAPS_API_KEY || ''
+      }
+    }
+  },
+  web: {
+    bundler: 'metro'
+  },
+  plugins: ['expo-location'],
+  extra: {
+    googleMapsApiKey: process.env.GOOGLE_MAPS_API_KEY || null
+  }
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,10 @@
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
+
+jest.mock('expo-location', () => ({
+  Accuracy: { Balanced: 2 },
+  hasServicesEnabledAsync: jest.fn(),
+  getCurrentPositionAsync: jest.fn(),
+  watchPositionAsync: jest.fn(),
+  getForegroundPermissionsAsync: jest.fn(),
+  requestForegroundPermissionsAsync: jest.fn(),
+}));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "expo-location-map",
+  "version": "1.0.0",
+  "private": true,
+  "main": "expo",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "test": "jest",
+    "lint": "eslint . --ext .ts,.tsx --max-warnings 0",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "expo-location": "~16.5.2",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.2.0",
+    "react-native": "0.74.1",
+    "react-native-maps": "1.18.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/react": "18.2.66",
+    "@types/react-native": "0.73.0",
+    "babel-jest": "^29.7.0",
+    "eslint": "^8.57.0",
+    "eslint-config-expo": "^7.1.1",
+    "jest": "^29.7.0",
+    "jest-expo": "^51.0.1",
+    "react-test-renderer": "18.2.0",
+    "typescript": "^5.4.5"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.ts"],
+    "moduleFileExtensions": ["ts", "tsx", "js"],
+    "transformIgnorePatterns": [
+      "node_modules/(?!(jest-)?react-native|@react-native|expo(nent)?|@expo(nent)?/.*|react-native-.*|@react-navigation/.*)"
+    ]
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,22 @@
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaView, StyleSheet } from 'react-native';
+import { MapScreen } from './screens/MapScreen';
+import { colors } from './styles/colors';
+
+const App = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar style="dark" />
+      <MapScreen />
+    </SafeAreaView>
+  );
+};
+
+export default App;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+});

--- a/src/components/CenterOnUserButton.tsx
+++ b/src/components/CenterOnUserButton.tsx
@@ -1,0 +1,52 @@
+import type { FunctionComponent } from 'react';
+import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { colors } from '../styles/colors';
+import { borderRadius, spacing } from '../styles/dimensions';
+import { texts } from '../constants/strings';
+
+interface CenterOnUserButtonProps {
+  onPress: () => void;
+  disabled?: boolean;
+}
+
+export const CenterOnUserButton: FunctionComponent<CenterOnUserButtonProps> = ({
+  onPress,
+  disabled = false,
+}) => {
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={texts.map.centerOnUserButton}
+      accessibilityHint="Zentriert die Karte auf Ihre aktuelle Position"
+      activeOpacity={0.7}
+      onPress={onPress}
+      style={[styles.button, disabled && styles.buttonDisabled]}
+      disabled={disabled}
+    >
+      <Text style={styles.buttonText}>{texts.map.centerOnUserButton}</Text>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: colors.primary,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    borderRadius: borderRadius.md,
+    shadowColor: '#000000',
+    shadowOpacity: 0.15,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 4,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: colors.textInverted,
+    fontWeight: '600',
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});

--- a/src/components/PermissionBanner.tsx
+++ b/src/components/PermissionBanner.tsx
@@ -1,0 +1,124 @@
+import type { FunctionComponent } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { PermissionStatus } from '../types/location';
+import { texts } from '../constants/strings';
+import { colors } from '../styles/colors';
+import { borderRadius, spacing } from '../styles/dimensions';
+
+interface PermissionBannerProps {
+  status: PermissionStatus;
+  isRequesting: boolean;
+  onRequestPermission: () => void;
+  onOpenSettings: () => void;
+  errorMessage?: string | null;
+}
+
+export const PermissionBanner: FunctionComponent<PermissionBannerProps> = ({
+  status,
+  isRequesting,
+  onRequestPermission,
+  onOpenSettings,
+  errorMessage,
+}) => {
+  if (status === 'granted') {
+    return null;
+  }
+
+  const isBlocked = status === 'blocked';
+  const message = isBlocked
+    ? texts.permission.blockedMessage
+    : texts.permission.deniedMessage;
+
+  const actionLabel = isBlocked
+    ? texts.permission.settingsAction
+    : texts.permission.requestAction;
+
+  const handlePress = isBlocked ? onOpenSettings : onRequestPermission;
+
+  return (
+    <View
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      style={styles.container}
+    >
+      <View style={styles.textContainer}>
+        <Text style={styles.title}>{texts.permission.requestTitle}</Text>
+        <Text style={styles.message}>{message}</Text>
+        {errorMessage ? <Text style={styles.error}>{errorMessage}</Text> : null}
+      </View>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={actionLabel}
+        accessibilityHint={
+          isBlocked
+            ? 'Öffnet die Systemeinstellungen, um die Berechtigung manuell zu aktivieren.'
+            : 'Fragt die Standort-Berechtigung erneut an.'
+        }
+        onPress={handlePress}
+        disabled={isRequesting}
+        style={({ pressed }) => [
+          styles.actionButton,
+          pressed && !isRequesting ? styles.actionButtonPressed : null,
+          isRequesting ? styles.actionButtonDisabled : null,
+        ]}
+      >
+        {isRequesting ? (
+          <ActivityIndicator color={colors.textInverted} />
+        ) : (
+          <Text style={styles.actionLabel}>{actionLabel}</Text>
+        )}
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: colors.bannerBackground,
+    borderRadius: borderRadius.md,
+    padding: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.md,
+    marginHorizontal: spacing.md,
+    marginTop: spacing.md,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  title: {
+    fontWeight: '600',
+    color: colors.info,
+    marginBottom: spacing.xs,
+    fontSize: 15,
+  },
+  message: {
+    color: colors.text,
+    fontSize: 14,
+  },
+  error: {
+    color: colors.warning,
+    marginTop: spacing.xs,
+    fontSize: 13,
+  },
+  actionButton: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.sm,
+    minWidth: 120,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  actionButtonPressed: {
+    opacity: 0.85,
+  },
+  actionButtonDisabled: {
+    opacity: 0.6,
+  },
+  actionLabel: {
+    color: colors.textInverted,
+    fontWeight: '600',
+  },
+});

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -1,0 +1,26 @@
+export const texts = {
+  map: {
+    title: 'Karte',
+    centerOnUserButton: 'Meine Position zentrieren',
+    locationUnavailable: 'Standort konnte nicht ermittelt werden.',
+    gpsDisabled: 'Bitte aktivieren Sie die Standortdienste (GPS), um Ihre Position zu sehen.',
+    retry: 'Erneut versuchen'
+  },
+  permission: {
+    requestTitle: 'Standort verwenden',
+    requestMessage:
+      'Wir benötigen Ihren Standort, um Ihre aktuelle Position auf der Karte anzeigen zu können.',
+    deniedMessage:
+      'Ohne die Berechtigung können wir Ihre Position nicht anzeigen. Bitte erteilen Sie den Zugriff.',
+    blockedMessage:
+      'Die Berechtigung wurde vom System blockiert. Öffnen Sie die Einstellungen, um den Zugriff zu erlauben.',
+    requestAction: 'Berechtigung anfragen',
+    settingsAction: 'Einstellungen öffnen'
+  },
+  errors: {
+    timeout: 'Zeitüberschreitung bei der Standortbestimmung.',
+    unknown: 'Es ist ein unbekannter Fehler aufgetreten.'
+  }
+} as const;
+
+export type Texts = typeof texts;

--- a/src/hooks/__tests__/useCurrentPosition.test.ts
+++ b/src/hooks/__tests__/useCurrentPosition.test.ts
@@ -1,0 +1,125 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import * as Location from 'expo-location';
+import { useCurrentPosition } from '../useCurrentPosition';
+import type { PermissionStatus } from '../../types/location';
+
+const waitFor = async (expectation: () => void, timeout = 1000, interval = 20) => {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      expectation();
+      return;
+    } catch (error) {
+      if (Date.now() - start > timeout) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+};
+
+const renderCurrentPositionHook = async (permission: PermissionStatus) => {
+  const result: { current: ReturnType<typeof useCurrentPosition> } = {
+    current: undefined as unknown as ReturnType<typeof useCurrentPosition>,
+  };
+
+  const TestComponent = ({ status }: { status: PermissionStatus }) => {
+    result.current = useCurrentPosition(status);
+    return null;
+  };
+
+  let renderer: TestRenderer.ReactTestRenderer | undefined;
+
+  await act(async () => {
+    renderer = TestRenderer.create(<TestComponent status={permission} />);
+  });
+
+  if (!renderer) {
+    throw new Error('Renderer konnte nicht initialisiert werden.');
+  }
+
+  return {
+    result,
+    rerender: async (status: PermissionStatus) => {
+      await act(async () => {
+        renderer!.update(<TestComponent status={status} />);
+      });
+    },
+    unmount: () => renderer!.unmount(),
+  };
+};
+
+describe('useCurrentPosition', () => {
+  const hasServicesEnabledMock = jest.mocked(Location.hasServicesEnabledAsync);
+  const getCurrentPositionMock = jest.mocked(Location.getCurrentPositionAsync);
+  const watchPositionMock = jest.mocked(Location.watchPositionAsync);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hasServicesEnabledMock.mockReset();
+    getCurrentPositionMock.mockReset();
+    watchPositionMock.mockReset();
+  });
+
+  it('returns a coordinate when permission is granted', async () => {
+    const currentLocation: Location.LocationObject = {
+      coords: {
+        latitude: 52.5,
+        longitude: 13.4,
+        altitude: null,
+        accuracy: 5,
+        altitudeAccuracy: null,
+        heading: null,
+        speed: null,
+      },
+      timestamp: Date.now(),
+    };
+
+    hasServicesEnabledMock.mockResolvedValue(true);
+    getCurrentPositionMock.mockResolvedValue(currentLocation);
+    watchPositionMock.mockImplementation(async (_options, callback) => {
+      callback({
+        coords: {
+          latitude: 52.51,
+          longitude: 13.41,
+          altitude: null,
+          accuracy: 7,
+          altitudeAccuracy: null,
+          heading: null,
+          speed: null,
+        },
+        timestamp: Date.now(),
+      });
+
+      return {
+        remove: jest.fn(),
+      } as unknown as Location.LocationSubscription;
+    });
+
+    const hook = await renderCurrentPositionHook('granted');
+
+    await waitFor(() => {
+      expect(hook.result.current.position).toEqual({
+        latitude: 52.51,
+        longitude: 13.41,
+        accuracy: 7,
+      });
+    });
+
+    expect(getCurrentPositionMock).toHaveBeenCalled();
+    expect(watchPositionMock).toHaveBeenCalled();
+  });
+
+  it('provides a permission error when access is denied', async () => {
+    const hook = await renderCurrentPositionHook('denied');
+
+    await waitFor(() => {
+      expect(hook.result.current.error?.type).toBe('permission-denied');
+    });
+
+    expect(hasServicesEnabledMock).not.toHaveBeenCalled();
+    expect(getCurrentPositionMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useLocationPermission.test.ts
+++ b/src/hooks/__tests__/useLocationPermission.test.ts
@@ -1,0 +1,115 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { AppState } from 'react-native';
+import * as Location from 'expo-location';
+import { useLocationPermission } from '../useLocationPermission';
+
+const waitFor = async (expectation: () => void, timeout = 1000, interval = 20) => {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      expectation();
+      return;
+    } catch (error) {
+      if (Date.now() - start > timeout) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+};
+
+const renderPermissionHook = async () => {
+  const result: { current: ReturnType<typeof useLocationPermission> } = {
+    current: undefined as unknown as ReturnType<typeof useLocationPermission>,
+  };
+
+  const TestComponent = () => {
+    result.current = useLocationPermission();
+    return null;
+  };
+
+  let renderer: TestRenderer.ReactTestRenderer | undefined;
+
+  await act(async () => {
+    renderer = TestRenderer.create(<TestComponent />);
+  });
+
+  if (!renderer) {
+    throw new Error('Renderer konnte nicht initialisiert werden.');
+  }
+
+  return {
+    result,
+    rerender: async () => {
+      await act(async () => {
+        renderer!.update(<TestComponent />);
+      });
+    },
+    unmount: () => {
+      renderer!.unmount();
+    },
+  };
+};
+
+describe('useLocationPermission', () => {
+  const getForegroundPermissionsAsyncMock = jest.mocked(
+    Location.getForegroundPermissionsAsync
+  );
+  const requestForegroundPermissionsAsyncMock = jest.mocked(
+    Location.requestForegroundPermissionsAsync
+  );
+
+  beforeAll(() => {
+    jest.spyOn(AppState, 'addEventListener').mockImplementation(() => ({
+      remove: jest.fn(),
+    }));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requests permission on mount when allowed to ask again', async () => {
+    getForegroundPermissionsAsyncMock.mockResolvedValueOnce({
+      granted: false,
+      canAskAgain: true,
+      expires: 'never',
+      status: 'denied' as const,
+    });
+
+    requestForegroundPermissionsAsyncMock.mockResolvedValueOnce({
+      granted: true,
+      canAskAgain: true,
+      expires: 'never',
+      status: 'granted' as const,
+    });
+
+    const hook = await renderPermissionHook();
+
+    await waitFor(() => {
+      expect(hook.result.current.status).toBe('granted');
+    });
+
+    expect(getForegroundPermissionsAsyncMock).toHaveBeenCalledTimes(1);
+    expect(requestForegroundPermissionsAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks status as blocked when the system prevents re-requesting', async () => {
+    getForegroundPermissionsAsyncMock.mockResolvedValueOnce({
+      granted: false,
+      canAskAgain: false,
+      expires: 'never',
+      status: 'denied' as const,
+    });
+
+    const hook = await renderPermissionHook();
+
+    await waitFor(() => {
+      expect(hook.result.current.status).toBe('blocked');
+    });
+
+    expect(requestForegroundPermissionsAsyncMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCurrentPosition.ts
+++ b/src/hooks/useCurrentPosition.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as Location from 'expo-location';
+import type { LocationSubscription } from 'expo-location';
+import { texts } from '../constants/strings';
+import type { Coordinate, CurrentPositionState, LocationError, PermissionStatus } from '../types/location';
+
+const toCoordinate = (location: Location.LocationObject): Coordinate => ({
+  latitude: location.coords.latitude,
+  longitude: location.coords.longitude,
+  accuracy: location.coords.accuracy,
+});
+
+const toLocationError = (error: unknown): LocationError => {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = String((error as { code?: string }).code);
+    if (code === 'E_LOCATION_TIMEOUT') {
+      return { type: 'timeout', message: texts.errors.timeout };
+    }
+    if (code === 'E_LOCATION_SERVICES_DISABLED') {
+      return { type: 'services-disabled', message: texts.map.gpsDisabled };
+    }
+    if (code === 'E_LOCATION_UNAUTHORIZED') {
+      return { type: 'permission-denied', message: texts.permission.deniedMessage };
+    }
+  }
+
+  return {
+    type: 'unknown',
+    message:
+      error instanceof Error && error.message.length > 0
+        ? error.message
+        : texts.errors.unknown,
+  };
+};
+
+const initialState: CurrentPositionState = {
+  position: null,
+  locationObject: null,
+  isFetching: false,
+  error: null,
+};
+
+interface UseCurrentPositionResult extends CurrentPositionState {
+  startWatching: () => Promise<void>;
+  stopWatching: () => void;
+  refresh: () => Promise<void>;
+}
+
+export const useCurrentPosition = (
+  permissionStatus: PermissionStatus
+): UseCurrentPositionResult => {
+  const [{ position, locationObject, isFetching, error }, setState] =
+    useState<CurrentPositionState>(initialState);
+  const watcherRef = useRef<LocationSubscription | null>(null);
+  const isMountedRef = useRef(true);
+
+  const updateState = useCallback((partial: Partial<CurrentPositionState>) => {
+    setState((current) => {
+      if (!isMountedRef.current) {
+        return current;
+      }
+
+      return { ...current, ...partial };
+    });
+  }, []);
+
+  const stopWatching = useCallback(() => {
+    watcherRef.current?.remove();
+    watcherRef.current = null;
+    updateState({ isFetching: false });
+  }, [updateState]);
+
+  const startWatching = useCallback(async () => {
+    if (watcherRef.current) {
+      return;
+    }
+
+    updateState({ isFetching: true, error: null });
+
+    try {
+      const servicesEnabled = await Location.hasServicesEnabledAsync();
+      if (!servicesEnabled) {
+        updateState({
+          error: { type: 'services-disabled', message: texts.map.gpsDisabled },
+          isFetching: false,
+          position: null,
+          locationObject: null,
+        });
+        return;
+      }
+
+      const currentLocation = await Location.getCurrentPositionAsync({
+        accuracy: Location.Accuracy.Balanced,
+        timeout: 10000,
+      });
+      updateState({
+        position: toCoordinate(currentLocation),
+        locationObject: currentLocation,
+      });
+
+      watcherRef.current = await Location.watchPositionAsync(
+        {
+          accuracy: Location.Accuracy.Balanced,
+          distanceInterval: 25,
+          timeInterval: 5000,
+        },
+        (location) => {
+          updateState({
+            position: toCoordinate(location),
+            locationObject: location,
+          });
+        }
+      );
+    } catch (watchError) {
+      updateState({
+        error: toLocationError(watchError),
+        position: null,
+        locationObject: null,
+      });
+      stopWatching();
+    } finally {
+      updateState({ isFetching: false });
+    }
+  }, [stopWatching, updateState]);
+
+  const refresh = useCallback(async () => {
+    stopWatching();
+    await startWatching();
+  }, [startWatching, stopWatching]);
+
+  useEffect(() => {
+    if (permissionStatus === 'granted') {
+      startWatching();
+      return () => {
+        stopWatching();
+      };
+    }
+
+    stopWatching();
+    if (permissionStatus === 'denied') {
+      updateState({
+        error: { type: 'permission-denied', message: texts.permission.deniedMessage },
+        position: null,
+        locationObject: null,
+      });
+    } else if (permissionStatus === 'blocked') {
+      updateState({
+        error: { type: 'permission-denied', message: texts.permission.blockedMessage },
+        position: null,
+        locationObject: null,
+      });
+    } else {
+      updateState({ error: null, position: null, locationObject: null });
+    }
+  }, [permissionStatus, startWatching, stopWatching, updateState]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      stopWatching();
+    };
+  }, [stopWatching]);
+
+  return {
+    position,
+    locationObject,
+    isFetching,
+    error,
+    startWatching,
+    stopWatching,
+    refresh,
+  };
+};

--- a/src/hooks/useLocationPermission.ts
+++ b/src/hooks/useLocationPermission.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState, Linking, Platform } from 'react-native';
+import * as Location from 'expo-location';
+import type { PermissionStatus } from '../types/location';
+
+interface UseLocationPermissionResult {
+  status: PermissionStatus;
+  canAskAgain: boolean;
+  isRequesting: boolean;
+  error: string | null;
+  refreshStatus: () => Promise<PermissionStatus>;
+  requestPermission: () => Promise<PermissionStatus>;
+  openAppSettings: () => Promise<void>;
+}
+
+const toStatus = (response: Location.PermissionResponse): PermissionStatus => {
+  if (response.granted) {
+    return 'granted';
+  }
+
+  return response.canAskAgain ? 'denied' : 'blocked';
+};
+
+const UNKNOWN_ERROR_MESSAGE =
+  Platform.select({
+    ios: 'Die Berechtigungsabfrage ist fehlgeschlagen. Bitte versuchen Sie es erneut.',
+    android: 'Die Berechtigungsabfrage ist fehlgeschlagen. Bitte versuchen Sie es erneut.',
+    default: 'Die Berechtigungsabfrage ist fehlgeschlagen.',
+  }) ?? 'Die Berechtigungsabfrage ist fehlgeschlagen.';
+
+export const useLocationPermission = (): UseLocationPermissionResult => {
+  const [status, setStatus] = useState<PermissionStatus>('unknown');
+  const [canAskAgain, setCanAskAgain] = useState<boolean>(true);
+  const [isRequesting, setIsRequesting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const didRequestOnLoad = useRef(false);
+
+  const applyResponse = useCallback(
+    (response: Location.PermissionResponse): { status: PermissionStatus; canAskAgain: boolean } => {
+      const nextStatus = toStatus(response);
+      setStatus(nextStatus);
+      setCanAskAgain(response.canAskAgain);
+      return { status: nextStatus, canAskAgain: response.canAskAgain };
+    },
+    []
+  );
+
+  const refreshStatus = useCallback(async (): Promise<PermissionStatus> => {
+    try {
+      const response = await Location.getForegroundPermissionsAsync();
+      const result = applyResponse(response);
+      return result.status;
+    } catch (refreshError) {
+      setError(refreshError instanceof Error ? refreshError.message : UNKNOWN_ERROR_MESSAGE);
+      return status;
+    }
+  }, [applyResponse, status]);
+
+  const requestPermission = useCallback(async (): Promise<PermissionStatus> => {
+    setIsRequesting(true);
+    setError(null);
+    try {
+      const response = await Location.requestForegroundPermissionsAsync();
+      const result = applyResponse(response);
+      return result.status;
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : UNKNOWN_ERROR_MESSAGE);
+      return status;
+    } finally {
+      setIsRequesting(false);
+      didRequestOnLoad.current = true;
+    }
+  }, [applyResponse, status]);
+
+  const openAppSettings = useCallback(async () => {
+    await Linking.openSettings();
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+    const checkAndRequest = async () => {
+      try {
+        const response = await Location.getForegroundPermissionsAsync();
+        const { status: latestStatus, canAskAgain: canStillAsk } = applyResponse(response);
+
+        if (
+          isMounted &&
+          latestStatus !== 'granted' &&
+          canStillAsk &&
+          !didRequestOnLoad.current
+        ) {
+          didRequestOnLoad.current = true;
+          await requestPermission();
+        }
+      } catch (loadError) {
+        setError(loadError instanceof Error ? loadError.message : UNKNOWN_ERROR_MESSAGE);
+      }
+    };
+
+    checkAndRequest();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [applyResponse, requestPermission]);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState === 'active') {
+        refreshStatus();
+      }
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [refreshStatus]);
+
+  return {
+    status,
+    canAskAgain,
+    isRequesting,
+    error,
+    refreshStatus,
+    requestPermission,
+    openAppSettings,
+  };
+};

--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -1,0 +1,34 @@
+import type { Region } from 'react-native-maps';
+import type { Coordinate } from '../types/location';
+
+export const FALLBACK_COORDINATE: Coordinate = {
+  latitude: 52.520008,
+  longitude: 13.404954,
+};
+
+export const DEFAULT_REGION_DELTA = {
+  latitudeDelta: 0.05,
+  longitudeDelta: 0.05,
+};
+
+export const getRegionForCoordinate = (
+  coordinate: Coordinate | null,
+  delta: Partial<Pick<Region, 'latitudeDelta' | 'longitudeDelta'>> = DEFAULT_REGION_DELTA
+): Region => ({
+  latitude: coordinate?.latitude ?? FALLBACK_COORDINATE.latitude,
+  longitude: coordinate?.longitude ?? FALLBACK_COORDINATE.longitude,
+  latitudeDelta: delta.latitudeDelta ?? DEFAULT_REGION_DELTA.latitudeDelta,
+  longitudeDelta: delta.longitudeDelta ?? DEFAULT_REGION_DELTA.longitudeDelta,
+});
+
+export const isCoordinate = (value: unknown): value is Coordinate => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const maybeCoordinate = value as Partial<Coordinate>;
+  return (
+    typeof maybeCoordinate.latitude === 'number' &&
+    typeof maybeCoordinate.longitude === 'number'
+  );
+};

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,0 +1,234 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Linking,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import MapView, { PROVIDER_GOOGLE, type MapViewProps, type Region } from 'react-native-maps';
+import { CenterOnUserButton } from '../components/CenterOnUserButton';
+import { PermissionBanner } from '../components/PermissionBanner';
+import { texts } from '../constants/strings';
+import { useCurrentPosition } from '../hooks/useCurrentPosition';
+import { useLocationPermission } from '../hooks/useLocationPermission';
+import { DEFAULT_REGION_DELTA, getRegionForCoordinate } from '../lib/map';
+import { colors } from '../styles/colors';
+import { borderRadius, spacing } from '../styles/dimensions';
+
+const mapProvider: MapViewProps['provider'] = Platform.select({
+  android: PROVIDER_GOOGLE,
+  ios: undefined,
+  default: undefined,
+});
+
+export const MapScreen = () => {
+  const mapRef = useRef<MapView | null>(null);
+  const hasCenteredOnUserRef = useRef(false);
+  const {
+    status,
+    requestPermission,
+    openAppSettings,
+    isRequesting,
+    error: permissionError,
+  } = useLocationPermission();
+  const { position, isFetching, error: locationError, refresh } = useCurrentPosition(status);
+
+  const initialRegion: Region = useMemo(
+    () => getRegionForCoordinate(position, DEFAULT_REGION_DELTA),
+    [position?.latitude, position?.longitude]
+  );
+
+  const handleCenterOnUser = useCallback(() => {
+    if (!mapRef.current || !position) {
+      return;
+    }
+
+    const region = getRegionForCoordinate(position, DEFAULT_REGION_DELTA);
+    mapRef.current.animateToRegion(region, 600);
+  }, [position]);
+
+  useEffect(() => {
+    if (status !== 'granted' || !position || !mapRef.current) {
+      return;
+    }
+
+    if (!hasCenteredOnUserRef.current) {
+      hasCenteredOnUserRef.current = true;
+      const region = getRegionForCoordinate(position, DEFAULT_REGION_DELTA);
+      mapRef.current.animateToRegion(region, 600);
+    }
+  }, [position, status]);
+
+  useEffect(() => {
+    if (status !== 'granted') {
+      hasCenteredOnUserRef.current = false;
+    }
+  }, [status]);
+
+  const handleOpenSettings = useCallback(async () => {
+    try {
+      if (status === 'blocked') {
+        await openAppSettings();
+        return;
+      }
+
+      if (locationError?.type === 'services-disabled') {
+        // There is no universal API to open location settings, fall back to app settings.
+        await Linking.openSettings();
+      }
+    } catch (settingsError) {
+      Alert.alert('Aktion fehlgeschlagen', 'Die Einstellungen konnten nicht geöffnet werden.');
+    }
+  }, [locationError?.type, openAppSettings, status]);
+
+  const renderStatusBanner = () => {
+    if (status === 'unknown') {
+      return null;
+    }
+
+    if (status !== 'granted') {
+      return (
+        <PermissionBanner
+          status={status}
+          isRequesting={isRequesting}
+          onRequestPermission={requestPermission}
+          onOpenSettings={openAppSettings}
+          errorMessage={permissionError}
+        />
+      );
+    }
+
+    if (locationError) {
+      const isServicesDisabled = locationError.type === 'services-disabled';
+      const actionLabel = isServicesDisabled
+        ? texts.permission.settingsAction
+        : texts.map.retry;
+      const onPress = isServicesDisabled ? handleOpenSettings : refresh;
+
+      return (
+        <View style={styles.bannerContainer} accessibilityRole="alert">
+          <Text style={styles.bannerTitle}>{texts.map.locationUnavailable}</Text>
+          <Text style={styles.bannerMessage}>{locationError.message}</Text>
+          <View style={styles.bannerActions}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={actionLabel}
+              accessibilityHint={
+                locationError.type === 'services-disabled'
+                  ? 'Öffnet die Einstellungen, um Standortdienste zu aktivieren.'
+                  : 'Startet einen neuen Versuch, Ihre Position zu bestimmen.'
+              }
+              onPress={onPress}
+              style={({ pressed }) => [
+                styles.bannerButton,
+                pressed && !isFetching ? styles.bannerButtonPressed : null,
+                isFetching ? styles.bannerButtonDisabled : null,
+              ]}
+              disabled={isFetching}
+            >
+              <Text style={styles.bannerButtonText}>{actionLabel}</Text>
+            </Pressable>
+          </View>
+        </View>
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <View style={styles.container}>
+      <MapView
+        ref={(ref) => {
+          mapRef.current = ref;
+        }}
+        provider={mapProvider}
+        style={StyleSheet.absoluteFill}
+        showsUserLocation
+        showsMyLocationButton={false}
+        initialRegion={initialRegion}
+        accessibilityLabel="Interaktive Karte"
+      />
+      <View style={styles.topContainer}>{renderStatusBanner()}</View>
+      <View style={styles.buttonContainer} pointerEvents="box-none">
+        <CenterOnUserButton
+          onPress={handleCenterOnUser}
+          disabled={!position || status !== 'granted'}
+        />
+      </View>
+      {isFetching ? (
+        <View style={styles.loadingOverlay} pointerEvents="none">
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : null}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  topContainer: {
+    position: 'absolute',
+    top: spacing.lg,
+    left: 0,
+    right: 0,
+  },
+  buttonContainer: {
+    position: 'absolute',
+    bottom: spacing.lg,
+    right: spacing.lg,
+  },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.35)',
+  },
+  bannerContainer: {
+    backgroundColor: colors.bannerBackground,
+    marginHorizontal: spacing.md,
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    shadowColor: '#000000',
+    shadowOpacity: 0.12,
+    shadowOffset: { width: 0, height: 3 },
+    shadowRadius: 6,
+    elevation: 3,
+    gap: spacing.sm,
+  },
+  bannerTitle: {
+    fontWeight: '600',
+    color: colors.info,
+    fontSize: 16,
+  },
+  bannerMessage: {
+    color: colors.text,
+    fontSize: 14,
+  },
+  bannerActions: {
+    alignItems: 'flex-start',
+  },
+  bannerButton: {
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.sm,
+  },
+  bannerButtonPressed: {
+    opacity: 0.8,
+  },
+  bannerButtonDisabled: {
+    opacity: 0.6,
+  },
+  bannerButtonText: {
+    color: colors.textInverted,
+    fontWeight: '600',
+  },
+});

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -1,0 +1,9 @@
+export const colors = {
+  primary: '#0057D9',
+  background: '#FFFFFF',
+  text: '#1B1B1B',
+  textInverted: '#FFFFFF',
+  warning: '#D93025',
+  info: '#0B7285',
+  bannerBackground: '#E3F2FD',
+} as const;

--- a/src/styles/dimensions.ts
+++ b/src/styles/dimensions.ts
@@ -1,0 +1,11 @@
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+} as const;
+
+export const borderRadius = {
+  sm: 8,
+  md: 12,
+} as const;

--- a/src/types/location.ts
+++ b/src/types/location.ts
@@ -1,0 +1,21 @@
+import type { LocationObject } from 'expo-location';
+
+export type PermissionStatus = 'unknown' | 'granted' | 'denied' | 'blocked';
+
+export interface Coordinate {
+  latitude: number;
+  longitude: number;
+  accuracy?: number | null;
+}
+
+export interface LocationError {
+  type: 'timeout' | 'services-disabled' | 'permission-denied' | 'unknown';
+  message: string;
+}
+
+export interface CurrentPositionState {
+  position: Coordinate | null;
+  locationObject: LocationObject | null;
+  isFetching: boolean;
+  error: LocationError | null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "jsx": "react-native",
+    "lib": ["esnext"],
+    "moduleResolution": "node",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "types": ["jest", "react-native"],
+    "target": "esnext"
+  },
+  "extends": "expo/tsconfig.base"
+}


### PR DESCRIPTION
## Summary
- scaffold an Expo + TypeScript project configured for foreground location access on iOS and Android
- implement a full-screen map screen with permission prompts, retry flows, and a center-on-user control
- add reusable hooks, UI components, and tests along with detailed setup guidance in the README

## Testing
- `npm install` *(fails: registry returned 403 for scoped packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c87cf4f68c833286b897311362d49a